### PR TITLE
Write functionality to remove fav recipe from fav array

### DIFF
--- a/src/scripts.js
+++ b/src/scripts.js
@@ -43,13 +43,20 @@ function addRecipeToFavs(event) {
   event.target.classList.remove('far', 'fa-heart', 'unchecked-heart');
   event.target.classList.add('fas', 'fa-heart', 'checked-heart');
   let clickedRecipe = allRecipes.find(recipe => {
-    recipe.name === event.target.parentElement.children[0].innerText;
+    if(event.target.parentElement.children[0].innerText === recipe.name) {
       return recipe;
+    }
   })
-    currentUser.addToFavorites(clickedRecipe);
+  currentUser.addToFavorites(clickedRecipe);
 }
 
 function removeRecipeFromFavs(event) {
   event.target.classList.remove('fas', 'fa-heart', 'checked-heart');
   event.target.classList.add('far', 'fa-heart', 'unchecked-heart');
+  let clickedRecipe = allRecipes.find(recipe => {
+    if (recipe.name === event.target.parentElement.children[0].innerText) {
+      return recipe;
+    }
+  })
+  currentUser.removeFromFavorites(clickedRecipe);
 }


### PR DESCRIPTION
### Type of change made:

- [X] New feature (non-breaking change which adds functionality)

### Detailed Description

When user clicks the heart to add to fav array, the recipe is added. And when the user clicks the heart on the same recipe to remove it from their saved fave array, it does as expected. This and last pull request where completed as a team.

### Why is this change required? What problem does it solve?

So if the user changes their mind on fav-ing it, they can remove it.

### Were there any challenges that arose while implementing this feature? If so, how were the addressed?

We noticed that our fav array was holding on one name instead of the correct names. Had to put our conditional into an if statement, which fixed the problem

### Files modified:
- [X] scripts.js

